### PR TITLE
added results for Windows, Linux

### DIFF
--- a/tests/index.html
+++ b/tests/index.html
@@ -252,11 +252,50 @@
               <td>Icon is spoken as “love, image”</td>
               <td>Icon is spelled as “love”</td>
             </tr>
+            <tr>
+              <th scope="row">Orca</th>
+              <td>Firefox 42.0</td>
+              <td>Ubuntu Linux 64-bit 14.04</td>
+              <td>Icon is spoken as “love, image”</td>
+              <td>Icon is spoken as “love image”</td>
+              <td>Icon is spelled as “l-o-v-e image”</td>
+            </tr>
+            <tr>
+              <th scope="row">JAWS</th>
+              <td>Firefox 42.0</td>
+              <td>Windows 7 64-bit</td>
+              <td>Icon is spoken as “graphic, love”</td>
+              <td>Icon is spoken as “graphic love”</td>
+              <td>Icon is spelled as “l-o-v-e”</td>
+            </tr>
+            <tr>
+              <th scope="row">JAWS</th><!--failz-->
+              <td>IE 11</td>
+              <td>Windows 7 64-bit</td>
+              <td>Icon is spoken as “graphic, love”</td>
+              <td>Icon is not spoken and sentence broken up into 2 lines</td>
+              <td>Icon is spelled as two spaces</td>
+            </tr>
+            <tr>
+              <th scope="row">NVDA</th>
+              <td>IE 11</td>
+              <td>Windows 7 64-bit</td>
+              <td>Icon is spoken as “graphic, love”</td>
+              <td>Icon is spoken as “graphic love”</td>
+              <td>Icon is spelled as “graphic l-o-v-e”</td>
+            </tr>
+              <th scope="row">NVDA</th>
+              <td>Firefox 42.0</td>
+              <td>Windows 7 64-bit</td>
+              <td>Icon is spoken as “graphic, love”</td>
+              <td>Icon is spoken as “graphic love”</td>
+              <td>Icon is spelled as “graphic l-o-v-e”</td>
+            </tr>
           </tbody>
         </table>
 
         <h3>Issues</h3>
-        <p>None so far :)</p>
+        <p>Internet Explorer is ignoring the aria-label on an item with an explicit role.</p>
         <!-- <ul>
           <li></li>
         </ul> -->


### PR DESCRIPTION
We need to investigate what exactly is tripping up IE/JAWS. Is it that image role isn't seen as valid enough to read out an aria-label, or is the problem aria-label itself, or does it have to do with how IE deals with characters/glyphs it doesn't normally know?
